### PR TITLE
Handle reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # bedrock-redis ChangeLog
 
 ### Changed
-- Update redis dependency.
+- **BREAKING**: Update redis dependency.
+- Handle more events.
+- Handle reconnects with slow backoff and random delay fuzz.
 
 ## 2.0.1 - 2016-03-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # bedrock-redis ChangeLog
 
+### Changed
+- Update redis dependency.
+
 ## 2.0.1 - 2016-03-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,15 @@
 # bedrock-redis ChangeLog
 
-## [Unreleased
-
-## [2.0.1] - 2016-03-15
+## 2.0.1 - 2016-03-15
 
 ### Changed
 - Update bedrock dependencies.
 
-## [2.0.0] - 2016-03-03
+## 2.0.0 - 2016-03-03
 
 ### Changed
 - Update package dependencies for npm v3 compatibility.
 
-## [1.0.0] - 2016-01-31
+## 1.0.0 - 2016-01-31
 
 - See git history for changes.
-
-[Unreleased]: https://github.com/digitalbazaar/bedrock-redis/compare/2.0.1...HEAD
-[2.0.1]: https://github.com/digitalbazaar/bedrock-redis/compare/2.0.0...2.0.1
-[2.0.0]: https://github.com/digitalbazaar/bedrock-redis/compare/1.0.0...2.0.0
-[1.0.0]: https://github.com/digitalbazaar/bedrock-redis/compare/0.0.0...1.0.0

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -30,12 +30,66 @@ bedrock.events.on('bedrock.start', function(callback) {
 });
 
 bedrock.events.on('bedrock.init', init);
+
 function init(callback) {
   logger.info(
-    'initializing Redis client: ' + config.redis.host + ':' +
+    'redis: initializing client: ' + config.redis.host + ':' +
     config.redis.port);
-  api.client = redis.createClient(config.redis.port, config.redis.host);
+  api.client = redis.createClient({
+    host: config.redis.host,
+    port: config.redis.port,
+    retry_strategy: function(options) {
+      if(options.error && options.error.code === 'ECONNREFUSED') {
+        // End reconnecting on a specific error and flush all commands with an
+        // individual error
+        logger.error('redis: connection refused');
+        //return new Error('Redis: the server refused the connection');
+      }
+      if(options.total_retry_time > 1000 * 60 * 60) {
+        // End reconnecting after a specific timeout and flush all commands
+        // with a individual error
+        logger.error(
+          'redis: total retry time exhausted', options.total_retry_time);
+        // FIXME: improve error handling
+        return new Error('redis: retry time exhausted');
+      }
+      /*
+      if (options.times_connected > 10) {
+        // End reconnecting with built in error
+        return undefined;
+      }
+      */
+      // reconnect delay
+      // add slight random fuzz to unsync multiple client reconnects
+      var fuzz = Math.floor(Math.random() * 250);
+      var delay = Math.max(options.attempt * 200, 3000) + fuzz;
+      logger.info('redis: will reconnect in ' + delay + 'ms');
+      return delay;
+    }
+  });
+  api.client.on('ready', function() {
+    logger.info('redis: ready');
+  });
   api.client.on('connect', function() {
+    logger.info('redis: connected');
     callback();
+  });
+  api.client.on('reconnecting', function(params) {
+    logger.info('redis: reconnecting', {
+      attempt: params.attempt,
+      delay: params.delay,
+      totalRetryTime: params.total_retry_time,
+      timesConnected: params.times_connected
+    });
+  });
+  api.client.on('error', function(error) {
+    // FIXME: improve error handling
+    logger.error('redis:', error);
+  });
+  api.client.on('end', function() {
+    logger.info('redis: end');
+  });
+  api.client.on('warning', function(msg) {
+    logger.warning('redis:', msg);
   });
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-redis",
   "dependencies": {
-    "redis": "^0.12.1"
+    "redis": "^2.6.2"
   },
   "peerDependencies": {
     "bedrock": "^1.0.0"


### PR DESCRIPTION
This adds reconnect support, handles  more events, and has more logging output. This patch should stop servers that use bedrock-redis from crashing on redis restarts. It updates the redis lib dependency from a mid 2014 version one to a modern 2016 one. It's unclear how this might effect the (few?) users of this module. Due to the redis major API version change, an update of this module likely needs a major version update as well. Here are changes to check:
https://github.com/NodeRedis/node_redis/blob/master/changelog.md
