### PR TITLE
Expand configs for `createClient` to match node-redis.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # bedrock-redis ChangeLog
 
+## 4.1.0 - 2022-xx-xx
+
+### Added
+- Add `socket` and `client` configs. These map directly to the options
+  available on the node-redis `createClient` method.
+  
 ## 4.0.0 - 2022-10-05
 
 ### Added

--- a/lib/client.js
+++ b/lib/client.js
@@ -6,29 +6,37 @@ import {config} from '@bedrock/core';
 import {logger} from './logger.js';
 import redis from 'redis';
 
-export async function createClient({
-  host = config.redis.host,
-  port = config.redis.port,
-} = {}) {
-  logger.debug(`Initializing client at: ${host}:${port}`);
-  const client = redis.createClient({
-    socket: {
-      host,
-      port,
-      reconnectStrategy: attempt => {
-        const max = config.redis.retry.retries;
-        if(attempt > max) {
-          return new Error(`Exceeded max (${max}) connection attempts.`);
-        }
-        // Calculates a timeout based on current attempt and
-        // retry options from this modules config.
-        const timeout = retry.createTimeout(attempt, config.redis.retry);
-        logger.info(
-          `Attempt ${attempt} failed, will reconnect in ${timeout}ms`);
-        return timeout;
+export async function createClient({host, port} = {}) {
+  const {socket: socketOptions, client: clientOptions} = config.redis;
+  // allow override of host and port
+  if(host) {
+    socketOptions.host = host;
+  }
+  if(port) {
+    socketOptions.port = port;
+  }
+  const socket = {
+    // merge socket options from config
+    ...socketOptions,
+    reconnectStrategy: attempt => {
+      const max = config.redis.retry.retries;
+      if(attempt > max) {
+        return new Error(`Exceeded max (${max}) connection attempts.`);
       }
-    }
-  });
+      // Calculates a timeout based on current attempt and
+      // retry options from this modules config.
+      const timeout = retry.createTimeout(attempt, config.redis.retry);
+      logger.info(
+        `Attempt ${attempt} failed, will reconnect in ${timeout}ms`);
+      return timeout;
+    },
+  };
+  if(clientOptions.url) {
+    logger.debug(`Initializing client at: ${clientOptions.url}`);
+  } else {
+    logger.debug(`Initializing client at: ${host}:${port}`);
+  }
+  const client = redis.createClient({socket, ...clientOptions});
   client.on('connect', () => logger.debug(`Initiating connection.`));
   client.on('reconnecting', () => logger.debug(`Reconnecting...`));
   client.on('ready', () => logger.debug(`Connected to redis.`));

--- a/lib/config.js
+++ b/lib/config.js
@@ -6,8 +6,14 @@
 import {config} from '@bedrock/core';
 
 config.redis = {};
+// Provide backwards compatibility, these can also be set
+// in `socket`
 config.redis.host = 'localhost';
 config.redis.port = 6379;
+// node-redis 'socket' options
+config.redis.socket = {}
+// node-redis other client options
+config.redis.client = {}
 // retry backoff control
 config.redis.retry = {
   // min retry delay (ms)


### PR DESCRIPTION
This adds two additional bedrock configs that allow for more options to be passed in to the`node-redis` `createClient` function. 
The list of the available options can be seen [here](https://github.com/redis/node-redis/blob/master/docs/client-configuration.md)

This was spurred by the need for the `username` and `password` options when creating a client. With these updates, those values can be set in the configs as 
```js
config.redis.client = {
	username: 'some_username',
	password: 'some_password'
}
```